### PR TITLE
Implements deletion from AVL Tree

### DIFF
--- a/avl.py
+++ b/avl.py
@@ -148,8 +148,10 @@ class AVLTree:
                 self.root.parent = None
             elif node is parent.left:
                 parent.assign_left(subtree_root)
+                parent.balance += 1
             else:
                 parent.assign_right(subtree_root)
+                parent.balance -= 1
             self.publish('balanced', tree=self, root=subtree_root)
             node = parent
 

--- a/avl.py
+++ b/avl.py
@@ -140,10 +140,13 @@ class AVLTree:
                 return
             # Determine rotation necessary to rebalance tree
             elif node.balance > 1:
-                subtree_root = self.rotate_left(node)
+                same = node.right.balance >= 0
+                rotate = self.rotate_left if same else self.rotate_right_left
             else:
-                subtree_root = self.rotate_right(node)
+                same = node.left.balance <= 0
+                rotate = self.rotate_right if same else self.rotate_left_right
             # Attach rebalanced subtree to grandparent, or tree root
+            subtree_root = rotate(node)
             if parent is None:
                 self.root = subtree_root
                 self.root.parent = None

--- a/avl.py
+++ b/avl.py
@@ -36,6 +36,7 @@ class AVLTree:
                 node = node.right
                 continue
 
+            self.publish('delete', tree=self, node=node)
             parent = node.parent
             if node.balance > 0:
                 # Node is right-heavy, find next-larger child node and put its

--- a/example.py
+++ b/example.py
@@ -9,6 +9,7 @@ from grapher import EventAnimator
 def fully_graphed_tree(base_name):
     event_bus = EventBus()
     animator = EventAnimator(base_name)
+    event_bus.subscribe('delete', animator.graph_delete)
     event_bus.subscribe('insert', animator.graph_insert)
     event_bus.subscribe('rotate', animator.graph_rotation)
     event_bus.subscribe('balanced', animator.graph_rebalanced)
@@ -17,7 +18,8 @@ def fully_graphed_tree(base_name):
 
 def main():
     tree = fully_graphed_tree('example')
-    tree.bulk_insert([434, 812, 957, 163, 285, 231])
+    tree.bulk_insert([43, 81, 95, 16, 28, 23, 63, 57])
+    tree.delete(16)
 
     tree = fully_graphed_tree('balanced_inserts')
     tree.bulk_insert(random.sample(range(100, 1000), 32))

--- a/grapher.py
+++ b/grapher.py
@@ -26,8 +26,12 @@ class EventAnimator:
         self._frame_count = 0
         self.base_name = base_name
 
+    def graph_delete(self, topic, message):
+        marks = MarkedNodes({message['node']}, hue=0.9)
+        self._write_image(graph_avl_tree(message['tree'], marked_nodes=marks))
+
     def graph_insert(self, topic, message):
-        marks = MarkedNodes({message['node']}, hue=0.3)
+        marks = MarkedNodes({message['node']}, hue=0.4)
         self._write_image(graph_avl_tree(message['tree'], marked_nodes=marks))
 
     def graph_rebalanced(self, topic, message):
@@ -36,7 +40,7 @@ class EventAnimator:
         self._write_image(graph_avl_tree(message['tree'], marked_nodes=marks))
 
     def graph_rotation(self, topic, message):
-        marks = MarkedNodes(message['nodes'], hue=0.9)
+        marks = MarkedNodes(message['nodes'], hue=0.7)
         self._write_image(graph_avl_tree(message['tree'], marked_nodes=marks))
 
     def _write_image(self, graph):
@@ -48,7 +52,7 @@ class MarkedNodes:
     def __init__(self, nodes, hue=0):
         self.nodes = nodes
         self.edge_color = self._create_color(hue, 0.2)
-        self.fill_color = self._create_color(hue, 0.94)
+        self.fill_color = self._create_color(hue, 0.92)
 
     def __contains__(self, other):
         return other in self.nodes

--- a/test_avl.py
+++ b/test_avl.py
@@ -155,6 +155,8 @@ def test_delete_reattach_right(Tree):
     'insert, delete, expected', [
         ((4, 2, 6, 7), 2, (6, 4, 7)),  # rotate left
         ((4, 2, 6, 1), 6, (2, 1, 4)),  # rotate right
+        ((4, 2, 6, 5), 2, (5, 4, 6)),  # rotate right-left
+        ((4, 2, 6, 3), 6, (3, 2, 4)),  # rotate left-right
     ]
 )
 def test_delete_single_rotation(Tree, insert, delete, expected):

--- a/test_avl.py
+++ b/test_avl.py
@@ -169,3 +169,15 @@ def test_delete_single_rotation(Tree, insert, delete, expected):
     assert tree.root.balance == 0
     assert tree.root.left.balance == 0
     assert tree.root.right.balance == 0
+
+
+def test_delete_double_rotation(Tree):
+    """Tests deletion resulting in a double rotation."""
+    tree = Tree(16, 8, 24, 4, 12, 20, 28, 2, 6, 10, 32, 1, 3)
+    tree.delete(20)
+    assert tree.root.value == 8
+    assert tree.root.left.value == 4
+    assert tree.root.right.value == 16
+    assert tree.root.balance == 0
+    assert tree.root.left.balance == -1
+    assert tree.root.right.balance == 0

--- a/test_avl.py
+++ b/test_avl.py
@@ -75,3 +75,97 @@ def test_double_rotation(Tree):
     assert tree.root.left.value == 2
     assert tree.root.left.left.value == 1
     assert tree.root.left.right.value == 3
+
+
+def test_delete_nonexisting(tree):
+    """Tests deletion of nonexisting key raises KeyError."""
+    tree.insert(1)
+    with pytest.raises(KeyError):
+        tree.delete(2)
+
+
+def test_delete_root(tree):
+    """Tests deletion of singular root node."""
+    tree.insert(1)
+    tree.delete(1)
+    assert tree.root is None
+
+
+@pytest.mark.parametrize(
+    'insert, delete, exp_root, exp_balance', [
+        ((1, 2), 1, 2, 0),
+        ((1, 2), 2, 1, 0),
+        ((4, 3), 3, 4, 0),
+        ((4, 3), 4, 3, 0),
+        ((2, 1, 3), 1, 2, 1),
+        ((2, 1, 3), 2, 1, 1),  # Implementation-defined, prefer left node
+        ((2, 1, 3), 3, 2, -1),
+    ]
+)
+def test_delete_simple(Tree, insert, delete, exp_root, exp_balance):
+    """Tests deletion of root/leaf nodes requiring no rotation."""
+    tree = Tree(insert)
+    tree.delete(delete)
+    assert tree.root.value == exp_root
+    assert tree.root.balance == exp_balance
+
+
+@pytest.mark.parametrize(
+    'insert, deletes, expected', [
+        ((3, 2, 4, 1, 5), (2, 4), (3, 1, 5)),
+        ((3, 2, 4, 1, 5), (3, 4), (2, 1, 5)),
+        ((3, 1, 5, 2, 4), (1, 5), (3, 2, 4)),
+        ((4, 2, 6, 1, 3, 5), (4, 1, 6), (3, 2, 5)),
+    ]
+)
+def test_delete_attach_without_rotation(Tree, insert, deletes, expected):
+    """Tests selective pruning of nodes and reattaching them to parents."""
+    tree = Tree(insert)
+    for key in deletes:
+        tree.delete(key)
+    root, left, right = expected
+    assert tree.root.value == root
+    assert tree.root.left.value == left
+    assert tree.root.right.value == right
+    # Tree should be fully balanced
+    assert tree.root.balance == 0
+    assert tree.root.left.balance == 0
+    assert tree.root.right.balance == 0
+
+
+def test_delete_reattach(Tree):
+    """Removing the root from a 2-depth V should reattach nodes correctly."""
+    tree = Tree(3, 2, 4, 1, 5)
+    tree.delete(3)
+    assert tree.root.value == 2
+    assert tree.root.right.value == 4
+    assert tree.root.left.value == 1
+
+
+def test_delete_reattach_right(Tree):
+    """Removing the root from a 2-depth V should reattach nodes correctly."""
+    tree = Tree(3, 2, 4, 5)
+    tree.delete(3)
+    assert tree.root.value == 4
+    assert tree.root.right.value == 5
+    assert tree.root.left.value == 2
+
+
+@pytest.mark.parametrize(
+    'insert, delete, expected', [
+        ((4, 2, 6, 7), 2, (6, 4, 7)),  # rotate left
+        ((4, 2, 6, 1), 6, (2, 1, 4)),  # rotate right
+    ]
+)
+def test_delete_single_rotation(Tree, insert, delete, expected):
+    """Tests deletion resulting in a single rotation."""
+    tree = Tree(insert)
+    tree.delete(delete)
+    root, left, right = expected
+    assert tree.root.value == root
+    assert tree.root.left.value == left
+    assert tree.root.right.value == right
+    # Tree should be fully balanced
+    assert tree.root.balance == 0
+    assert tree.root.left.balance == 0
+    assert tree.root.right.balance == 0


### PR DESCRIPTION
This adds a `.delete()` method to the AVLTree class that searches for the given value and removes the associated node, or raises `KeyError` for nonexisting values. The tree is then rebalanced such that the balance factor invariant holds for all nodes.

The graphing is also updated to account for the new operation and the example is expanded to demonstrate a removal and subsequent (double) rebalancing.