### PR TITLE
Graphing simplifications

### DIFF
--- a/grapher.py
+++ b/grapher.py
@@ -2,23 +2,22 @@ from collections import deque
 from colorsys import hls_to_rgb
 from functools import lru_cache
 
-from pydot import (
-    Dot,
-    Edge,
-    Node)
+from pydot import Dot, Edge, Node
 
 GRAPH_STYLE = {
-    'bgcolor': 'white',
-    'graph_type': 'graph',
-    'nodesep': 0.2,
-    'pad': "0.5, 0.5, 0, 0.5"}
+    "bgcolor": "white",
+    "graph_type": "graph",
+    "nodesep": 0.2,
+    "pad": "0.5, 0.5, 0, 0.5",
+}
 NODE_STYLE = {
-    'fillcolor': 'lightyellow',
-    'fontname': 'ubuntu mono bold',
-    'fontsize': 18,
-    'penwidth': 2,
-    'shape': 'circle',
-    'style': 'filled'}
+    "fillcolor": "lightyellow",
+    "fontname": "ubuntu mono bold",
+    "fontsize": 18,
+    "penwidth": 2,
+    "shape": "circle",
+    "style": "filled",
+}
 
 
 class EventAnimator:
@@ -27,24 +26,24 @@ class EventAnimator:
         self.base_name = base_name
 
     def graph_delete(self, topic, message):
-        marks = MarkedNodes({message['node']}, hue=0.9)
-        self._write_image(graph_avl_tree(message['tree'], marked_nodes=marks))
+        marks = MarkedNodes({message["node"]}, hue=0.9)
+        self._write_image(graph_avl_tree(message["tree"], marked_nodes=marks))
 
     def graph_insert(self, topic, message):
-        marks = MarkedNodes({message['node']}, hue=0.4)
-        self._write_image(graph_avl_tree(message['tree'], marked_nodes=marks))
+        marks = MarkedNodes({message["node"]}, hue=0.4)
+        self._write_image(graph_avl_tree(message["tree"], marked_nodes=marks))
 
     def graph_rebalanced(self, topic, message):
-        root = message['root']
+        root = message["root"]
         marks = MarkedNodes({root, root.left, root.right}, hue=0.6)
-        self._write_image(graph_avl_tree(message['tree'], marked_nodes=marks))
+        self._write_image(graph_avl_tree(message["tree"], marked_nodes=marks))
 
     def graph_rotation(self, topic, message):
-        marks = MarkedNodes(message['nodes'], hue=0.7)
-        self._write_image(graph_avl_tree(message['tree'], marked_nodes=marks))
+        marks = MarkedNodes(message["nodes"], hue=0.7)
+        self._write_image(graph_avl_tree(message["tree"].root, marked_nodes=marks))
 
     def _write_image(self, graph):
-        graph.write_png(f'{self.base_name}_{self._frame_count}.png')
+        graph.write_png(f"{self.base_name}_{self._frame_count}.png")
         self._frame_count += 1
 
 
@@ -60,23 +59,23 @@ class MarkedNodes:
     @staticmethod
     def _create_color(hue, lightness):
         rgb_color = (round(val * 255) for val in hls_to_rgb(hue, lightness, 1))
-        return '#{:02x}{:02x}{:02x}'.format(*rgb_color)
+        return "#{:02x}{:02x}{:02x}".format(*rgb_color)
 
 
 class TreeGrapher:
-    def __init__(self, tree, cache_size=256):
+    def __init__(self, root, cache_size=256):
+        if root is None:
+            raise ValueError("Cannot graph an empty tree")
         self._height = self._cached_node_height(cache_size)
-        self.tree = tree
+        self.root = root
 
     def create_graph(self, marked_nodes=None):
-        if self.tree.root is None:
-            raise ValueError('Cannot graph an empty tree')
         graph = Dot(**GRAPH_STYLE)
-        graph.set_edge_defaults(color='navy', penwidth=2)
+        graph.set_edge_defaults(color="navy", penwidth=2)
         graph.set_node_defaults(**NODE_STYLE)
         marked_nodes = marked_nodes or set()
-        self._draw_node(graph, self.tree.root, marked_nodes)
-        nodes = deque([self.tree.root])
+        self._draw_node(graph, self.root, marked_nodes)
+        nodes = deque([self.root])
         while nodes:
             node = nodes.popleft()
             if node.left:
@@ -96,21 +95,23 @@ class TreeGrapher:
         been updated yet. A cache ensures that determining the height of all
         subtrees in the tree only takes time on the order of the node count.
         """
+
         @lru_cache(maxsize=cache_size)
         def height(node):
             if node is None:
                 return -1
             return 1 + max(height(node.left), height(node.right))
+
         return height
 
     def _draw_divider(self, graph, node):
         """Draws a vertical divider to distinguish left/right child nodes."""
-        marker_style = {'label': '', 'width': 0, 'height': 0, 'style': 'invis'}
+        marker_style = {"label": "", "width": 0, "height": 0, "style": "invis"}
         source = node.value
         for _ in range(self._height(node)):
-            label = f':{source}'
+            label = f":{source}"
             graph.add_node(Node(label, **marker_style))
-            graph.add_edge(Edge(source, label, style='invis', weight=100))
+            graph.add_edge(Edge(source, label, style="invis", weight=100))
             source = label
 
     def _draw_node(self, graph, node, marked_nodes):
@@ -124,9 +125,9 @@ class TreeGrapher:
         else:
             graph.add_node(Node(node.value))
         if node.parent:
-            style = {'penwidth': 4 if self._tallest_sibling(node) else 2}
+            style = {"penwidth": 4 if self._tallest_sibling(node) else 2}
             if node in marked_nodes and node.parent in marked_nodes:
-                style['color'] = marked_nodes.edge_color
+                style["color"] = marked_nodes.edge_color
             graph.add_edge(Edge(node.parent.value, node.value, **style))
 
     def _tallest_sibling(self, node):
@@ -138,5 +139,5 @@ class TreeGrapher:
 
 
 def graph_avl_tree(tree, marked_nodes=None):
-    grapher = TreeGrapher(tree)
+    grapher = TreeGrapher(tree.root)
     return grapher.create_graph(marked_nodes=marked_nodes)

--- a/grapher.py
+++ b/grapher.py
@@ -79,11 +79,11 @@ class TreeGrapher:
         while nodes:
             node = nodes.popleft()
             if node.left:
-                self._draw_node(graph, node.left, marked_nodes)
+                self._draw_node(graph, node.left, marked_nodes, parent=node)
                 nodes.append(node.left)
             self._draw_divider(graph, node)
             if node.right:
-                self._draw_node(graph, node.right, marked_nodes)
+                self._draw_node(graph, node.right, marked_nodes, parent=node)
                 nodes.append(node.right)
         return graph
 
@@ -114,7 +114,7 @@ class TreeGrapher:
             graph.add_edge(Edge(source, label, style="invis", weight=100))
             source = label
 
-    def _draw_node(self, graph, node, marked_nodes):
+    def _draw_node(self, graph, node, marked_nodes, parent=None):
         """Draws actual node and edge up to parent, thick if imbalanced.
 
         Alternate colors for marked nodes are determined based on the fill or
@@ -124,15 +124,14 @@ class TreeGrapher:
             graph.add_node(Node(node.value, fillcolor=marked_nodes.fill_color))
         else:
             graph.add_node(Node(node.value))
-        if node.parent:
-            style = {"penwidth": 4 if self._tallest_sibling(node) else 2}
-            if node in marked_nodes and node.parent in marked_nodes:
+        if parent is not None:
+            style = {"penwidth": 4 if self._tallest_sibling(parent, node) else 2}
+            if node in marked_nodes and parent in marked_nodes:
                 style["color"] = marked_nodes.edge_color
-            graph.add_edge(Edge(node.parent.value, node.value, **style))
+            graph.add_edge(Edge(parent.value, node.value, **style))
 
-    def _tallest_sibling(self, node):
+    def _tallest_sibling(self, parent, node):
         """Returns whether the node is a taller subtree than its sibling."""
-        parent = node.parent
         if node is parent.left:
             return self._height(node) > self._height(parent.right)
         return self._height(node) > self._height(parent.left)

--- a/test_traversal.py
+++ b/test_traversal.py
@@ -1,58 +1,66 @@
 import pytest
 
 from avl import AVLTree
-from traversal import (
-    breadth_first_traverser,
-    ordered_iterative,
-    ordered_recursive)
+from traversal import breadth_first, depth_first_inorder, ordered_iterative
 
 
-@pytest.fixture(params=[ordered_iterative, ordered_recursive])
+@pytest.fixture(params=[depth_first_inorder, ordered_iterative])
 def in_order_traverser(request):
     """Returns an in-order traverser."""
     return request.param
 
 
-@pytest.mark.parametrize('traverser', [
-    breadth_first_traverser, ordered_iterative, ordered_recursive])
+@pytest.mark.parametrize(
+    "traverser", [breadth_first, depth_first_inorder, ordered_iterative]
+)
 def test_empty_tree_traversal(traverser):
     assert list(traverser(AVLTree())) == []
 
 
-@pytest.mark.parametrize('tree, expected', [
-    (AVLTree(4, 2, 6, 1, 3, 5, 7), [1, 2, 3, 4, 5, 6, 7]),
-    (AVLTree(4, 2, 6, 1, 5, 7), [1, 2, 4, 5, 6, 7]),
-    (AVLTree(4, 2, 6, 3, 5, 7), [2, 3, 4, 5, 6, 7]),
-    (AVLTree(range(30, 100)), list(range(30, 100))),
-])
+@pytest.mark.parametrize(
+    "tree, expected",
+    [
+        (AVLTree(4, 2, 6, 1, 3, 5, 7), [1, 2, 3, 4, 5, 6, 7]),
+        (AVLTree(4, 2, 6, 1, 5, 7), [1, 2, 4, 5, 6, 7]),
+        (AVLTree(4, 2, 6, 3, 5, 7), [2, 3, 4, 5, 6, 7]),
+        (AVLTree(range(30, 100)), list(range(30, 100))),
+    ],
+)
 def test_ordered_traversal(in_order_traverser, tree, expected):
     assert list(in_order_traverser(tree)) == expected
 
 
-@pytest.mark.parametrize('tree, child, expected', [
-    (AVLTree(4, 2, 6, 1, 3), 'left', [1, 2, 3]),
-    (AVLTree(4, 2, 6, 5, 7), 'right', [5, 6, 7]),
-    (AVLTree(4, 2, 6, 1), 'left', [1, 2]),
-    (AVLTree(4, 2, 6, 5), 'right', [5, 6]),
-])
+@pytest.mark.parametrize(
+    "tree, child, expected",
+    [
+        (AVLTree(4, 2, 6, 1, 3), "left", [1, 2, 3]),
+        (AVLTree(4, 2, 6, 5, 7), "right", [5, 6, 7]),
+        (AVLTree(4, 2, 6, 1), "left", [1, 2]),
+        (AVLTree(4, 2, 6, 5), "right", [5, 6]),
+    ],
+)
 def test_partial_ordered_traversal(in_order_traverser, tree, child, expected):
     subtree = getattr(tree.root, child)
     assert list(in_order_traverser(subtree)) == expected
 
 
-@pytest.mark.parametrize('rank_order', [
-    [4, 2, 6, 1, 3, 5, 7], [4, 2, 6, 9], [4, 2, 6, 1]])
+@pytest.mark.parametrize(
+    "rank_order", [[4, 2, 6, 1, 3, 5, 7], [4, 2, 6, 9], [4, 2, 6, 1]]
+)
 def test_rank_ordered_traversal(rank_order):
     tree = AVLTree(rank_order)
-    assert list(breadth_first_traverser(tree)) == rank_order
+    assert list(breadth_first(tree)) == rank_order
 
 
-@pytest.mark.parametrize('tree, child, expected', [
-    (AVLTree(4, 2, 6, 1, 3), 'left', [2, 1, 3]),
-    (AVLTree(4, 2, 6, 5, 7), 'right', [6, 5, 7]),
-    (AVLTree(4, 2, 6, 1), 'left', [2, 1]),
-    (AVLTree(4, 2, 6, 5), 'right', [6, 5]),
-])
+@pytest.mark.parametrize(
+    "tree, child, expected",
+    [
+        (AVLTree(4, 2, 6, 1, 3), "left", [2, 1, 3]),
+        (AVLTree(4, 2, 6, 5, 7), "right", [6, 5, 7]),
+        (AVLTree(4, 2, 6, 1), "left", [2, 1]),
+        (AVLTree(4, 2, 6, 5), "right", [6, 5]),
+    ],
+)
 def test_partial_rank_ordered_traversal(tree, child, expected):
     subtree = getattr(tree.root, child)
-    assert list(breadth_first_traverser(subtree)) == expected
+    assert list(breadth_first(subtree)) == expected

--- a/traversal.py
+++ b/traversal.py
@@ -3,8 +3,9 @@
 from collections import deque
 
 
-def breadth_first_traverser(tree):
+def breadth_first(tree):
     """Rank-ordered breadth-first traverser based on a FIFO-queue."""
+
     def _traverser(node):
         nodes = deque([node])
         while nodes:
@@ -14,11 +15,13 @@ def breadth_first_traverser(tree):
                 nodes.append(node.left)
             if node.right is not None:
                 nodes.append(node.right)
+
     return _traverse_tree_or_node(_traverser, tree)
 
 
 def ordered_iterative(tree):
     """In-order depth-first-search, implemented as iterative generator."""
+
     def _traverser(node):
         backtracking = False
         parents = deque([None])
@@ -34,22 +37,51 @@ def ordered_iterative(tree):
                 continue
             backtracking = True
             node = parents.pop()
+
     return _traverse_tree_or_node(_traverser, tree)
 
 
-def ordered_recursive(tree):
+def depth_first_inorder(tree):
     """In-order depth-first-search, implemented as recursive generator."""
-    def _traverser(node):
+
+    def _in_order_traverser(node):
         if node.left is not None:
-            yield from ordered_recursive(node.left)
+            yield from _in_order_traverser(node.left)
         yield node.value
         if node.right is not None:
-            yield from ordered_recursive(node.right)
-    return _traverse_tree_or_node(_traverser, tree)
+            yield from _in_order_traverser(node.right)
+
+    return _traverse_tree_or_node(_in_order_traverser, tree)
+
+
+def depth_first_preorder(tree):
+    """Pre-order depth-first-search, implemented as recursive generator."""
+
+    def _pre_order_traverser(node):
+        yield node.value
+        if node.left is not None:
+            yield from _pre_order_traverser(node.left)
+        if node.right is not None:
+            yield from _pre_order_traverser(node.right)
+
+    return _traverse_tree_or_node(_pre_order_traverser, tree)
+
+
+def depth_first_postorder(tree):
+    """Post-order depth-first-search, implemented as recursive generator."""
+
+    def _post_order_traverser(node):
+        if node.left is not None:
+            yield from _post_order_traverser(node.left)
+        if node.right is not None:
+            yield from _post_order_traverser(node.right)
+        yield node.value
+
+    return _traverse_tree_or_node(_post_order_traverser, tree)
 
 
 def _traverse_tree_or_node(traverser, node):
     """Applies the traverser to the tree's root, or the given starting node."""
-    if hasattr(node, 'root'):
+    if hasattr(node, "root"):
         node = node.root
-    return traverser(node) if node is not None else []
+    return iter([]) if node is None else traverser(node)

--- a/traversal_benchmarks.py
+++ b/traversal_benchmarks.py
@@ -7,27 +7,25 @@ post-traversal sorted breadth-first traversal.
 import timeit
 
 from avl import AVLTree
-from traversal import (
-    breadth_first_traverser,
-    ordered_iterative,
-    ordered_recursive)
+from traversal import breadth_first, depth_first_inorder, ordered_iterative
 
 ORDERED_TRAVERSERS = [
-    ('iterative', lambda tree: lambda: list(ordered_iterative(tree))),
-    ('recursive', lambda tree: lambda: list(ordered_recursive(tree))),
-    ('sorted-bfs', lambda tree: lambda: sorted(breadth_first_traverser(tree)))]
+    ("iterative", lambda tree: lambda: list(ordered_iterative(tree))),
+    ("recursive", lambda tree: lambda: list(depth_first_inorder(tree))),
+    ("sorted-bfs", lambda tree: lambda: sorted(breadth_first(tree))),
+]
 
 
 def main():
     for tree_size in (100, 1000, 10000):
         tree = AVLTree(range(tree_size))
-        print(f'Ordered traversal of a tree size {tree_size}')
+        print(f"Ordered traversal of a tree size {tree_size}")
         for name, test_func_creator in ORDERED_TRAVERSERS:
             test_func = test_func_creator(tree)
             assert test_func() == sorted(range(tree_size))
             best = min(timeit.repeat(test_func, number=1000, repeat=3))
-            print(f'  * [{name}]: {best * 1000:.1f}μs')
+            print(f"  * [{name}]: {best * 1000:.1f}μs")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Simplifies graphing by removing the dependency on a `parent` attribute, and drawing a tree from any starting node going down. This allows for trivial trees made from for example namedtuples to be graphed.

Adds depth-first recursive traversers to make the fuill set of _inorder_, _preorder_ and _postorder_. Updates style to apply basic Black formatting.