### PR TITLE
Red black trees and improved rendering

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,9 +1,8 @@
 import random
 
-from sherwood.events.animator import tree_renderer
+from sherwood.events import tree_renderer
 from sherwood.renderers import draw_avl_tree, draw_redblack_tree
-from sherwood.trees.avl import AVLTree
-from sherwood.trees.redblack import RedBlackTree
+from sherwood.trees import AVLTree, RedBlackTree
 
 
 def main():

--- a/example.py
+++ b/example.py
@@ -2,16 +2,28 @@ import random
 
 from sherwood.events.animator import tree_renderer
 from sherwood.trees.avl import AVLTree
+from sherwood.trees.redblack import RedBlackTree
+from sherwood.utils.draw import draw_avl_tree, draw_redblack_tree
 
 
 def main():
-    with tree_renderer(AVLTree, "example") as tree:
-        for value in [43, 81, 95, 16, 28, 23, 63, 57]:
+    example_values = [43, 81, 95, 16, 28, 23, 63, 57]
+    with tree_renderer(AVLTree, "avl-example", renderer=draw_avl_tree) as tree:
+        for value in example_values:
             tree.insert(value)
         tree.delete(16)
 
-    with tree_renderer(AVLTree, "balanced_inserts") as tree:
-        for value in random.sample(range(100, 1000), 32):
+    with tree_renderer(RedBlackTree, "rb-example", renderer=draw_redblack_tree) as tree:
+        for value in example_values:
+            tree.insert(value)
+
+    insert_sample = random.sample(range(100, 1000), 32)
+    with tree_renderer(AVLTree, "avl-inserts", renderer=draw_avl_tree) as tree:
+        for value in insert_sample:
+            tree.insert(value)
+
+    with tree_renderer(RedBlackTree, "rb-inserts", renderer=draw_redblack_tree) as tree:
+        for value in insert_sample:
             tree.insert(value)
 
 

--- a/example.py
+++ b/example.py
@@ -1,9 +1,9 @@
 import random
 
 from sherwood.events.animator import tree_renderer
+from sherwood.renderers import draw_avl_tree, draw_redblack_tree
 from sherwood.trees.avl import AVLTree
 from sherwood.trees.redblack import RedBlackTree
-from sherwood.utils.draw import draw_avl_tree, draw_redblack_tree
 
 
 def main():

--- a/example.py
+++ b/example.py
@@ -25,6 +25,21 @@ def main():
         for value in insert_sample:
             tree.insert(value)
 
+    with tree_renderer(RedBlackTree, "rb-recolor", renderer=draw_redblack_tree) as tree:
+        for value in [13, 16, 8, 17, 15, 11, 5, 14]:
+            tree.insert(value)
+        tree.delete(14)
+        for value in [12, 10, 6, 3, 9]:
+            tree.insert(value)
+        tree.delete(9)
+        for value in [4, 2, 1]:
+            tree.insert(value)
+
+    with tree_renderer(RedBlackTree, "rb-deletes", renderer=draw_redblack_tree) as tree:
+        for value in [4, 2, 6]:
+            tree.insert(value)
+        tree.delete(6)
+
 
 if __name__ == "__main__":
     main()

--- a/src/sherwood/events/__init__.py
+++ b/src/sherwood/events/__init__.py
@@ -1,4 +1,4 @@
 from .animator import Animator, tree_renderer
-from .base import Bus, Event
+from .base import AnimationNode, Bus, Event
 
-__all__ = "Animator", "Bus", "Event", "tree_renderer"
+__all__ = "AnimationNode", "Animator", "Bus", "Event", "tree_renderer"

--- a/src/sherwood/events/animator.py
+++ b/src/sherwood/events/animator.py
@@ -28,6 +28,9 @@ class Animator:
     def graph_rebalanced(self, event: Event) -> None:
         self._render(AnimationFrame(event.root, event.nodes, marked_hue=0.62))
 
+    def graph_recolored(self, event: Event) -> None:
+        self._render(AnimationFrame(event.root, event.nodes, marked_hue=0.15))
+
     def graph_rotation(self, event: Event) -> None:
         self._render(AnimationFrame(event.root, event.nodes, marked_hue=0.83))
 
@@ -45,6 +48,7 @@ class Animator:
         bus = Bus()
         bus.subscribe("delete", self.graph_delete)
         bus.subscribe("insert", self.graph_insert)
+        bus.subscribe("recolor", self.graph_recolored)
         bus.subscribe("rotate", self.graph_rotation)
         bus.subscribe("balanced", self.graph_rebalanced)
         return bus

--- a/src/sherwood/events/animator.py
+++ b/src/sherwood/events/animator.py
@@ -8,7 +8,7 @@ from types import TracebackType
 from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Type
 
 from ..trees.base import Node, Tree
-from ..utils.draw import Renderer, draw_tree
+from ..renderers import Renderer, draw_tree
 from .base import AnimationNode, Bus, Event
 
 

--- a/src/sherwood/events/animator.py
+++ b/src/sherwood/events/animator.py
@@ -7,8 +7,9 @@ from multiprocessing import Pool
 from types import TracebackType
 from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Type
 
-from ..trees.base import Node, Tree
 from ..renderers import Renderer, draw_tree
+from ..trees.base import Tree
+from ..typing import Node
 from .base import AnimationNode, Bus, Event
 
 

--- a/src/sherwood/events/animator.py
+++ b/src/sherwood/events/animator.py
@@ -2,35 +2,38 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import dataclass
+from enum import Enum
 from multiprocessing import Pool
 from types import TracebackType
-from typing import Any, Iterator, List, NamedTuple, Optional, Set, Tuple, Type, Union
+from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Type
 
-from ..trees.base import BinaryNode, Node, Tree
-from ..utils.draw import MarkedNodes, tree_graph
-from .base import Bus, Event
+from ..trees.base import Node, Tree
+from ..utils.draw import Renderer, draw_tree
+from .base import AnimationNode, Bus, Event
 
 
 class Animator:
-    def __init__(self, base_name: str):
+    def __init__(self, renderer: Renderer, base_name: str):
         self._frame_count = 0
         self.base_name = base_name
+        self.renderer = renderer
         self.workers = Pool()
 
     def graph_delete(self, event: Event) -> None:
-        self._render(AnimationFrame(event.root, event.nodes, highlight_hue=0.9))
+        self._render(AnimationFrame(event.root, event.nodes, marked_hue=0.95))
 
     def graph_insert(self, event: Event) -> None:
-        self._render(AnimationFrame(event.root, event.nodes, highlight_hue=0.4))
+        self._render(AnimationFrame(event.root, event.nodes, marked_hue=0.4))
 
     def graph_rebalanced(self, event: Event) -> None:
-        self._render(AnimationFrame(event.root, event.nodes, highlight_hue=0.6))
+        self._render(AnimationFrame(event.root, event.nodes, marked_hue=0.62))
 
     def graph_rotation(self, event: Event) -> None:
-        self._render(AnimationFrame(event.root, event.nodes, highlight_hue=0.7))
+        self._render(AnimationFrame(event.root, event.nodes, marked_hue=0.83))
 
     def _render(self, frame: AnimationFrame) -> None:
-        self.workers.apply_async(self.draw_graph, (frame.serialize(), self.frame_name))
+        draw_args = frame.serialize(), self.frame_name, self.renderer
+        self.workers.apply_async(self.draw_graph, draw_args)
 
     @property
     def frame_name(self) -> str:
@@ -43,10 +46,10 @@ class Animator:
         self.workers.join()
 
     @staticmethod
-    def draw_graph(serialized_frame: SerialFrame, name: str) -> None:
+    def draw_graph(serialized: SerialFrame, name: str, renderer: Renderer) -> None:
         """Multiprocess worker function to do the actual work of image rendering."""
-        frame = AnimationFrame.from_serialized(serialized_frame)
-        frame.render(name)
+        frame = AnimationFrame.from_serialized(serialized)
+        frame.render(name, renderer)
 
     def __enter__(self) -> Bus:
         bus = Bus()
@@ -68,50 +71,46 @@ class Animator:
 @dataclass
 class AnimationFrame:
     root: Node
-    highlighted_nodes: Set[Node]
-    highlight_hue: float = 0
+    marked: Set[Node]
+    marked_hue: float = 0
 
     @classmethod
     def from_serialized(cls, frame: SerialFrame) -> AnimationFrame:
-        ivalues = iter(frame.serialization)
-        root = node = BinaryNode(next(ivalues))
-        marked_nodes: Set[Node] = {root} if 0 in frame.node_indices else set()
+        serialization = iter(frame.serialization)
+        _branch, root_value, root_options = next(serialization)
+        root = node = AnimationNode(root_value, options=root_options)
+        marked: Set[Node] = {root} if 0 in frame.node_indices else set()
         stack = []
-        for idx, (branch_id, value) in enumerate(zip(ivalues, ivalues), 1):
+        for idx, (branch_id, value, options) in enumerate(serialization, 1):
             if branch_id == 0:
                 stack.append(node)
-                node.left = node = BinaryNode(value)
+                node.left = node = AnimationNode(value, options=options)
             else:
                 for _ in range(1, branch_id):
                     node = stack.pop()
-                node.right = node = BinaryNode(value)
+                node.right = node = AnimationNode(value, options=options)
             if idx in frame.node_indices:
-                marked_nodes.add(node)
-        return cls(root, marked_nodes, frame.hue)
+                marked.add(node)
+        return cls(root, marked, frame.hue)
 
     def serialize(self) -> SerialFrame:
         serialization: List[Any] = []
         node_indices: List[int] = []
         cur_branch = 0
         for node_index, (node, new_branch) in enumerate(dfs_branch_encoded(self.root)):
-            if node in self.marked_nodes:
+            if node in self.marked:
                 node_indices.append(node_index)
             change, cur_branch = 1 + cur_branch - new_branch, new_branch
-            serialization.append(change)
-            serialization.append(node.value)
-        return SerialFrame(serialization[1:], node_indices, self.highlight_hue)
+            serialization.append((change, node.value, node_extra_values(node)))
+        return SerialFrame(serialization, node_indices, self.marked_hue)
 
-    @property
-    def marked_nodes(self) -> MarkedNodes:
-        return MarkedNodes(self.highlighted_nodes, hue=self.highlight_hue)
-
-    def render(self, name: str) -> None:
-        graph = tree_graph(self.root, marked_nodes=self.marked_nodes)
+    def render(self, name: str, renderer: Renderer) -> None:
+        graph = renderer(self.root, self.marked, self.marked_hue)
         graph.write_png(name)
 
 
 class SerialFrame(NamedTuple):
-    serialization: List[Union[Any, int]]
+    serialization: List[Tuple[int, Any, Dict[str, Any]]]
     node_indices: List[int]
     hue: float
 
@@ -125,8 +124,22 @@ def dfs_branch_encoded(
         yield from dfs_branch_encoded(node.right, branch_id=branch_id)
 
 
+def node_extra_values(node: Node) -> Dict[str, Any]:
+    def node_attrs() -> Iterator[Tuple[str, Any]]:
+        for attr, value in vars(node).items():
+            if attr in {"value", "left", "right"}:
+                continue
+            if isinstance(value, Enum):
+                value = value.name
+            yield attr, value
+
+    return dict(node_attrs())
+
+
 @contextmanager
-def tree_renderer(tree_type: Type[Tree], base_name: str) -> Iterator[Tree]:
-    animator = Animator(base_name)
+def tree_renderer(
+    tree_type: Type[Tree], base_name: str, renderer: Renderer = draw_tree
+) -> Iterator[Tree]:
+    animator = Animator(renderer, base_name)
     with animator as bus:
         yield tree_type(event_bus=bus)

--- a/src/sherwood/events/base.py
+++ b/src/sherwood/events/base.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional, Set, final
 
-from ..trees.base import BinaryNode, Comparable, Node
+from ..trees.base import BinaryNode
+from ..typing import Node
 
 
 @final
 @dataclass(eq=False)
 class AnimationNode(BinaryNode):
-    value: Comparable
     left: Optional[AnimationNode] = None
     right: Optional[AnimationNode] = None
     options: Dict[str, Any] = field(default_factory=dict)

--- a/src/sherwood/events/base.py
+++ b/src/sherwood/events/base.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Callable, Dict, Set
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional, Set, final
 
-from ..trees.base import Node
+from ..trees.base import BinaryNode, Comparable, Node
+
+
+@final
+@dataclass(eq=False)
+class AnimationNode(BinaryNode):
+    value: Comparable
+    left: Optional[AnimationNode] = None
+    right: Optional[AnimationNode] = None
+    options: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/src/sherwood/renderers/__init__.py
+++ b/src/sherwood/renderers/__init__.py
@@ -1,0 +1,22 @@
+from .base import Renderer, TreeRenderer
+from .properties import (
+    color_marked_node_edge,
+    imbalanced_edge_weight,
+    outline_marked_node,
+    red_black_node_color,
+)
+
+draw_tree: Renderer = TreeRenderer(
+    edge_attr_funcs=[color_marked_node_edge],
+    node_attr_funcs=[outline_marked_node],
+)
+
+draw_avl_tree: Renderer = TreeRenderer(
+    edge_attr_funcs=[color_marked_node_edge, imbalanced_edge_weight],
+    node_attr_funcs=[outline_marked_node],
+)
+
+draw_redblack_tree: Renderer = TreeRenderer(
+    edge_attr_funcs=[color_marked_node_edge],
+    node_attr_funcs=[outline_marked_node, red_black_node_color],
+)

--- a/src/sherwood/renderers/__init__.py
+++ b/src/sherwood/renderers/__init__.py
@@ -20,3 +20,6 @@ draw_redblack_tree: Renderer = TreeRenderer(
     edge_attr_funcs=[color_marked_node_edge],
     node_attr_funcs=[outline_marked_node, red_black_node_color],
 )
+
+
+__all__ = "Renderer", "draw_tree", "draw_avl_tree", "draw_redblack_tree"

--- a/src/sherwood/renderers/base.py
+++ b/src/sherwood/renderers/base.py
@@ -4,7 +4,7 @@ from typing import Callable, Iterator, Optional, Sequence, Set, Tuple, Union
 
 from pydot import Dot, Edge, Node as DotNode
 
-from ..trees.base import Node
+from ..typing import Node
 from .context import DrawContext
 
 GRAPH_STYLE = {

--- a/src/sherwood/renderers/context.py
+++ b/src/sherwood/renderers/context.py
@@ -5,7 +5,7 @@ from typing import Callable, Optional, Set
 
 from pydot import Dot
 
-from ..trees.base import Node
+from ..typing import Node
 
 
 @dataclass

--- a/src/sherwood/renderers/context.py
+++ b/src/sherwood/renderers/context.py
@@ -1,0 +1,48 @@
+from colorsys import hls_to_rgb
+from dataclasses import dataclass
+from functools import cached_property, lru_cache
+from typing import Callable, Optional, Set
+
+from pydot import Dot
+
+from ..trees.base import Node
+
+
+@dataclass
+class DrawContext:
+    graph: Dot
+    marked_nodes: Set[Node]
+    marked_hue: float
+
+    @property
+    def edge_color(self) -> str:
+        return hls_to_html(self.marked_hue, 0.35, 0.75)
+
+    @property
+    def fill_color(self) -> str:
+        return hls_to_html(self.marked_hue, 0.92, 0.75)
+
+    @cached_property
+    def height(self) -> Callable[[Optional[Node]], int]:
+        """Provides a node-height function to return the height of its subtree.
+
+        The height is determined by (recursively) going down left and right
+        subtrees. This avoids incorrect results in AVL trees with unupdated
+        balance factors, and works for trees without 'tallest child' metadata.
+
+        A cache ensures that determining the height of any/all nodes in
+        the trees takes no more than O(n) time across all lookups.
+        """
+
+        @lru_cache(maxsize=1024)
+        def height(node: Optional[Node]) -> int:
+            if node is None:
+                return -1
+            return 1 + max(height(node.left), height(node.right))
+
+        return height
+
+
+def hls_to_html(hue: float, lightness: float, saturation: float) -> str:
+    rgb_color = hls_to_rgb(hue, lightness, saturation)
+    return "#{:02x}{:02x}{:02x}".format(*(round(val * 255) for val in rgb_color))

--- a/src/sherwood/renderers/properties.py
+++ b/src/sherwood/renderers/properties.py
@@ -1,0 +1,37 @@
+from typing import Any
+
+from ..events.base import AnimationNode
+from ..trees.base import Node
+from ..trees.redblack import RBNode
+from .base import DotAttrs, DrawContext
+
+
+def color_marked_node_edge(context: DrawContext, node: Node, parent: Node) -> DotAttrs:
+    if {node, parent} <= context.marked_nodes:
+        yield "color", context.edge_color
+
+
+def imbalanced_edge_weight(context: DrawContext, node: Node, parent: Node) -> DotAttrs:
+    """Increases the edge's pen width if the current node is the parent's tallest."""
+    if node is parent.left and context.height(node) > context.height(parent.right):
+        yield "penwidth", 3
+    elif node is parent.right and context.height(node) > context.height(parent.left):
+        yield "penwidth", 3
+
+
+def outline_marked_node(context: DrawContext, node: Node) -> DotAttrs:
+    if node in context.marked_nodes:
+        yield "color", context.edge_color
+        yield "peripheries", 2
+
+
+def red_black_node_color(context: DrawContext, node: Node) -> DotAttrs:
+    color: Any
+    if isinstance(node, RBNode):
+        color = node.color.name
+    elif isinstance(node, AnimationNode):
+        color = node.options.get("color")
+    if color == "black":
+        yield "fillcolor", "#555555"
+    elif color == "red":
+        yield "fillcolor", "#dd1133"

--- a/src/sherwood/renderers/properties.py
+++ b/src/sherwood/renderers/properties.py
@@ -1,9 +1,10 @@
 from typing import Any
 
 from ..events.base import AnimationNode
-from ..trees.base import Node
 from ..trees.redblack import RBNode
-from .base import DotAttrs, DrawContext
+from ..typing import Node
+from .base import DotAttrs
+from .context import DrawContext
 
 
 def color_marked_node_edge(context: DrawContext, node: Node, parent: Node) -> DotAttrs:

--- a/src/sherwood/traversal.py
+++ b/src/sherwood/traversal.py
@@ -3,7 +3,8 @@
 from collections import deque
 from typing import Any, Callable, Deque, Iterator, Optional, Union, cast
 
-from .trees.base import Node, Tree
+from .trees.base import Tree
+from .typing import Node
 
 Treelike = Union[Node, Tree]
 

--- a/src/sherwood/trees/__init__.py
+++ b/src/sherwood/trees/__init__.py
@@ -1,0 +1,5 @@
+from .avl import AVLNode, AVLTree
+from .base import BinaryNode, Tree
+from .redblack import RBNode, RedBlackTree
+
+__all__ = "AVLNode", "AVLTree", "BinaryNode", "RBNode", "RedBlackTree", "Tree"

--- a/src/sherwood/trees/avl.py
+++ b/src/sherwood/trees/avl.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Iterator, List, Optional, cast, final
+from typing import Any, Iterator, List, Optional, final
 
+from ..typing import unwrap
 from .base import BinaryNode, Branch, Tree
 from .utils import left_edge_path, right_edge_path
 
@@ -22,7 +23,7 @@ class AVLTree(Tree):
     def delete(self, key: Any) -> None:
         """Deletes a key from the AVL tree, or raises if it doesn't exist."""
         lineage = list(self._trace(key))
-        node = cast(AVLNode, lineage[-1])
+        node = unwrap(lineage[-1])
         self.publish("delete", node)
         if node.balance > 0:
             # Node is right-heavy, find next-larger child node and put its
@@ -127,7 +128,7 @@ class AVLTree(Tree):
         deleted: Branch,
         new: Optional[AVLNode] = None,
     ) -> None:
-        node = cast(AVLNode, lineage.pop())
+        node = unwrap(lineage.pop())
         if deleted is Branch.left:
             node.balance += 1
             node.left = new
@@ -143,10 +144,10 @@ class AVLTree(Tree):
                 return
             # Determine rotation necessary to rebalance tree
             elif node.balance > 1:
-                same = node.right.balance >= 0  # type: ignore[union-attr]
+                same = unwrap(node.right).balance >= 0
                 rotate = self.rotate_left if same else self.rotate_right_left
             else:
-                same = node.left.balance <= 0  # type: ignore[union-attr]
+                same = unwrap(node.left).balance <= 0
                 rotate = self.rotate_right if same else self.rotate_left_right
             # Attach rebalanced subtree to grandparent, or tree root
             subtree = rotate(node)
@@ -160,13 +161,13 @@ class AVLTree(Tree):
                 parent.right = subtree
                 parent.balance -= balance_change
             self.publish("balanced", subtree, subtree.left, subtree.right)
-            if balance_change == 0:
-                break  # Subtree height did not change, rebalancing is done
-            node = cast(AVLNode, parent)
+            if balance_change == 0 or parent is None:
+                break  # Subtree height did not change or lineage exhausted: done
+            node = unwrap(parent)
 
     def rotate_left(self, root: AVLNode) -> AVLNode:
         """Hoists the right child to this node's parent position."""
-        pivot = cast(AVLNode, root.right)
+        pivot = unwrap(root.right)
         self.publish("rotate.left", root, pivot)
         root.right, pivot.left = pivot.left, root
         pivot.balance -= 1
@@ -175,7 +176,7 @@ class AVLTree(Tree):
 
     def rotate_right(self, root: AVLNode) -> AVLNode:
         """Hoists the left child to this node's parent position."""
-        pivot = cast(AVLNode, root.left)
+        pivot = unwrap(root.left)
         self.publish("rotate.right", root, pivot)
         root.left, pivot.right = pivot.right, root
         pivot.balance += 1
@@ -184,8 +185,8 @@ class AVLTree(Tree):
 
     def rotate_left_right(self, root: AVLNode) -> AVLNode:
         """Hoists the left->right grandchild to this node's parent position."""
-        smallest = cast(AVLNode, root.left)
-        pivot = cast(AVLNode, smallest.right)
+        smallest = unwrap(root.left)
+        pivot = unwrap(smallest.right)
         self.publish("rotate.leftright", root, pivot, smallest)
         smallest.right, root.left = pivot.left, pivot.right
         pivot.left, pivot.right = smallest, root
@@ -196,8 +197,8 @@ class AVLTree(Tree):
 
     def rotate_right_left(self, root: AVLNode) -> AVLNode:
         """Hoists the right->left grandchild to this node's parent position."""
-        largest = cast(AVLNode, root.right)
-        pivot = cast(AVLNode, largest.left)
+        largest = unwrap(root.right)
+        pivot = unwrap(largest.left)
         self.publish("rotate.rightleft", root, pivot, largest)
         root.right, largest.left = pivot.left, pivot.right
         pivot.left, pivot.right = root, largest

--- a/src/sherwood/trees/avl.py
+++ b/src/sherwood/trees/avl.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Iterator, List, Optional, cast, final
 
 from .base import BinaryNode, Branch, Tree
+from .utils import left_edge_path, right_edge_path
 
 
 @final
@@ -27,7 +28,7 @@ class AVLTree(Tree):
             # Node is right-heavy, find next-larger child node and put its
             # value on the deletion target. Prune the selected node by
             # attaching its children to its parent, and rebalance that.
-            *subtree, tail = left_edge_path(cast(AVLNode, node.right))
+            *subtree, tail = left_edge_path(node.right)
             lineage.extend(subtree)
             node.value = tail.value
             deleted = Branch.right if tail is node.right else Branch.left
@@ -204,19 +205,3 @@ class AVLTree(Tree):
         largest.balance = int(pivot.balance < 0)
         pivot.balance = 0
         return pivot
-
-
-def right_edge_path(node: AVLNode) -> Iterator[AVLNode]:
-    """Yields the given node and all children attached on a right edge."""
-    while node.right is not None:
-        yield node
-        node = node.right
-    yield node
-
-
-def left_edge_path(node: AVLNode) -> Iterator[AVLNode]:
-    """Yields the given node and all children attached on a left edge."""
-    while node.left is not None:
-        yield node
-        node = node.left
-    yield node

--- a/src/sherwood/trees/base.py
+++ b/src/sherwood/trees/base.py
@@ -14,6 +14,11 @@ if TYPE_CHECKING:
 class Branch(Enum):
     left = auto()
     right = auto()
+    __inverted__ = {left: right, right: left}
+
+    @property
+    def inverse(self) -> Branch:
+        return Branch(self.__inverted__[self.value])
 
 
 @dataclass

--- a/src/sherwood/trees/base.py
+++ b/src/sherwood/trees/base.py
@@ -3,35 +3,17 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, Iterable, Optional, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Iterable, Optional
+
+from ..typing import Comparable, Node
 
 if TYPE_CHECKING:
     from ..events import Bus
 
 
-CT = TypeVar("CT", bound="Comparable")
-
-
 class Branch(Enum):
     left = auto()
     right = auto()
-
-
-class Comparable(Protocol):
-    def __lt__(self: CT, other: CT) -> bool:
-        ...
-
-
-class Node(Protocol):
-    value: Comparable
-
-    @property
-    def left(self) -> Optional[Node]:
-        ...
-
-    @property
-    def right(self) -> Optional[Node]:
-        ...
 
 
 @dataclass

--- a/src/sherwood/trees/redblack.py
+++ b/src/sherwood/trees/redblack.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum, auto
-from itertools import takewhile
-from typing import Any, Iterator, Optional, final
+from itertools import chain, takewhile, tee
+from typing import Any, Iterable, Iterator, Optional, final
 
-from .base import BinaryNode, Tree
+from .base import BinaryNode, Branch, Tree
 
 
 class Color(Enum):
@@ -26,11 +26,120 @@ class RBNode(BinaryNode):
     right: Optional[RBNode] = None
 
 
+@dataclass(frozen=True)
+class NodeRelations:
+    node: RBNode
+    parent: RBNode
+    dir: Branch
+
+    @property
+    def sibling(self):
+        return getattr(self.parent, self.dir.inverse.name)
+
+    @property
+    def close_cousin(self) -> Optional[RBNode]:
+        return getattr(self.sibling, self.dir.name)
+
+    @property
+    def distant_cousin(self) -> Optional[RBNode]:
+        return getattr(self.sibling, self.dir.inverse.name)
+
+    @classmethod
+    def from_node_parent(
+        cls, node: RBNode, parent: RBNode, direction=Branch
+    ) -> NodeRelations:
+        if node is parent.left:
+            direction = Branch.left
+        elif node is parent.right:
+            direction = Branch.right
+        return cls(node=node, parent=parent, dir=direction)
+
+
 class RedBlackTree(Tree):
     root: Optional[RBNode]
 
     def delete(self, key: Any) -> None:
-        raise NotImplementedError
+        lineage, lineage_copy = tee(reversed(list(self._trace(key))))
+        node = next(lineage_copy)
+        self.publish("delete", node)
+        if node.left is node.right is None and node is self.root:
+            self.root = None
+            self.publish("balanced")
+            return  # trivial case 1
+        elif node.left is not None and node.right is not None:
+            # Find closest relative of two children to limit removal space
+            left_children = list(right_edge_path(node.left))
+            right_children = list(left_edge_path(node.right))
+            *child_tree, tail = max(left_children, right_children, key=len)
+            node.value = tail.value
+            node = tail
+            lineage = chain(reversed(child_tree), lineage_copy)
+
+        if node.color is Color.red:
+            # Node has no children and is trivially removable
+            replace_black_or_prune(node, (target := next(lineage_copy)))
+            return self.publish("recolor", target)
+        elif (child := node.left or node.right) is not None:
+            # Node has a single (necessarily red) child, which takes this node's place
+            if node is self.root:
+                child.color = Color.black
+                self.root = child
+            else:
+                replace_black_or_prune(node, next(lineage_copy), replacement=child)
+            return self.publish("recolor", child)
+
+        parent = next(lineage_copy)
+        if node is parent.left:
+            branch = Branch.left
+            parent.left = None
+        else:
+            branch = Branch.right
+            parent.right = None
+
+        for relation in self.lineage_iterator(lineage, direction=branch):
+            if relation.parent is None:
+                # D2: We've arrived at the root, all work is done
+                return
+            elif (
+                is_black(relation.parent)
+                and is_black(relation.sibling)
+                and is_black(relation.close_cousin)
+                and is_black(relation.distant_cousin)
+            ):
+                # D1: Everything is black, paint sibling red and restore path lenghts
+                relation.sibling.color = Color.red
+                self.publish("recolor", relation.sibling)
+                continue
+            elif relation.sibling.color is Color.red:
+                # D3: Sibling is red with (necessarily) black children; rotate
+                is_left = relation.dir is Branch.left
+                rotate = self.rotate_left if is_left else self.rotate_right
+                subtree = rotate(
+                    relation.parent, relation.sibling, relation.distant_cousin
+                )
+                if relation.parent is self.root:
+                    self.root = subtree
+                self.publish("balanced", subtree, subtree.left, subtree.right)
+
+            if not is_black(relation.close_cousin):
+                # D5
+                return
+            elif not is_black(relation.distant_cousin):
+                # D6
+                return
+            else:
+                # D4: Sibling is black, both cousins are black, repaint sibling
+                invert_color(relation.sibling, relation.parent)
+                self.publish("recolor", relation.sibling, relation.parent)
+                return
+
+    def lineage_iterator(
+        self, node_path: Iterable[RBNode], direction=Branch
+    ) -> Iterator[NodeRelations]:
+        nodes, parents = tee(node_path)
+        next(parents, None)
+        for node, parent in zip(nodes, parents):
+            yield NodeRelations.from_node_parent(node, parent, direction=direction)
 
     def insert(self, key: Any) -> RBNode:
         if self.root is None:
@@ -55,6 +164,20 @@ class RedBlackTree(Tree):
             self.publish("insert", new)
             self.rebalance(new, reversed(lineage))
             return new
+
+    def _trace(self, key: Any) -> Iterator[RBNode]:
+        """Traces a path from the root down to the requested key, or raises KeyError."""
+        node = self.root
+        # yield None
+        while node is not None:
+            yield node
+            if key == node.value:
+                return
+            elif key < node.value:
+                node = node.left
+            else:
+                node = node.right
+        raise KeyError(f"key {key!r} does not exist in tree")
 
     def rebalance(self, node: RBNode, lineage: Iterator[RBNode]) -> None:
         """Rebalances the red-black tree after insertion of a new node."""
@@ -88,14 +211,18 @@ class RedBlackTree(Tree):
             self.publish("balanced", subtree, subtree.left, subtree.right)
             break
 
-    def rotate_left(self, root: RBNode, pivot: RBNode, tail: RBNode) -> RBNode:
+    def rotate_left(
+        self, root: RBNode, pivot: RBNode, tail: Optional[RBNode]
+    ) -> RBNode:
         """Hoists the pivot up to to be the new root of the given triple."""
         self.publish("rotate.left", root, pivot, tail)
         root.right, pivot.left = pivot.left, root
         invert_color(root, pivot)
         return pivot
 
-    def rotate_right(self, root: RBNode, pivot: RBNode, tail: RBNode) -> RBNode:
+    def rotate_right(
+        self, root: RBNode, pivot: RBNode, tail: Optional[RBNode]
+    ) -> RBNode:
         """Hoists the pivot up to to be the new root of the given triple."""
         self.publish("rotate.right", root, pivot, tail)
         root.left, pivot.right = pivot.right, root
@@ -119,6 +246,22 @@ class RedBlackTree(Tree):
         return pivot
 
 
+def is_black(node: Optional[RBNode]) -> bool:
+    """Whether or not a node is colored black, with NIL nodes considered black."""
+    return node is None or node.color is Color.black
+
+
+def replace_black_or_prune(
+    node: RBNode, parent: RBNode, replacement: Optional[RBNode] = None
+) -> None:
+    if replacement is not None:
+        replacement.color = Color.black
+    if parent.left is node:
+        parent.left = replacement
+    else:
+        parent.right = replacement
+
+
 def has_same_colored_children(node: RBNode) -> bool:
     return (
         node.left is not None
@@ -130,3 +273,19 @@ def has_same_colored_children(node: RBNode) -> bool:
 def invert_color(*nodes: Optional[RBNode]) -> None:
     for node in filter(None, nodes):
         node.color = node.color.inverse
+
+
+def left_edge_path(node: RBNode) -> Iterator[RBNode]:
+    """Yields the given node and all children attached on a left edge."""
+    while node.left is not None:
+        yield node
+        node = node.left
+    yield node
+
+
+def right_edge_path(node: RBNode) -> Iterator[RBNode]:
+    """Yields the given node and all children attached on a right edge."""
+    while node.right is not None:
+        yield node
+        node = node.right
+    yield node

--- a/src/sherwood/trees/redblack.py
+++ b/src/sherwood/trees/redblack.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum, auto
 from itertools import takewhile
-from typing import Any, Iterator, Optional, cast, final
+from typing import Any, Iterator, Optional, final
 
 from .base import BinaryNode, Tree
 
@@ -64,9 +64,9 @@ class RedBlackTree(Tree):
                 parent.color = Color.black
                 break
             grandparent = next(lineage)
-            if has_all_red_children(grandparent):
+            if has_same_colored_children(grandparent):
+                invert_color(grandparent, grandparent.left, grandparent.right)
                 node = grandparent
-                invert_color(node, cast(RBNode, node.left), cast(RBNode, node.right))
                 continue
             # Determine rotation necessary to rebalance tree
             if node is parent.left:
@@ -119,14 +119,14 @@ class RedBlackTree(Tree):
         return pivot
 
 
-def has_all_red_children(node: RBNode) -> bool:
+def has_same_colored_children(node: RBNode) -> bool:
     return (
         node.left is not None
         and node.right is not None
-        and node.left.color is node.right.color is Color.red
+        and node.left.color is node.right.color
     )
 
 
-def invert_color(*nodes: RBNode) -> None:
-    for node in nodes:
+def invert_color(*nodes: Optional[RBNode]) -> None:
+    for node in filter(None, nodes):
         node.color = node.color.inverse

--- a/src/sherwood/trees/redblack.py
+++ b/src/sherwood/trees/redblack.py
@@ -86,9 +86,7 @@ class RedBlackTree(Tree):
             else:
                 anchor.right = subtree
             self.publish("balanced", subtree, subtree.left, subtree.right)
-            if anchor is None or anchor.color is Color.black:
-                break
-            node = anchor
+            break
 
     def rotate_left(self, root: RBNode, pivot: RBNode, tail: RBNode) -> RBNode:
         """Hoists the pivot up to to be the new root of the given triple."""

--- a/src/sherwood/trees/redblack.py
+++ b/src/sherwood/trees/redblack.py
@@ -6,6 +6,7 @@ from itertools import chain, takewhile, tee
 from typing import Any, Iterable, Iterator, Optional, final
 
 from .base import BinaryNode, Branch, Tree
+from .utils import left_edge_path, right_edge_path
 
 
 class Color(Enum):
@@ -289,19 +290,3 @@ def has_same_colored_children(node: RBNode) -> bool:
 def invert_color(*nodes: Optional[RBNode]) -> None:
     for node in filter(None, nodes):
         node.color = node.color.inverse
-
-
-def left_edge_path(node: RBNode) -> Iterator[RBNode]:
-    """Yields the given node and all children attached on a left edge."""
-    while node.left is not None:
-        yield node
-        node = node.left
-    yield node
-
-
-def right_edge_path(node: RBNode) -> Iterator[RBNode]:
-    """Yields the given node and all children attached on a right edge."""
-    while node.right is not None:
-        yield node
-        node = node.right
-    yield node

--- a/src/sherwood/trees/redblack.py
+++ b/src/sherwood/trees/redblack.py
@@ -62,11 +62,13 @@ class RedBlackTree(Tree):
         for parent in takewhile(lambda node: node.color is not Color.black, lineage):
             if parent is self.root:
                 parent.color = Color.black
+                self.publish("recolor", parent)
                 break
             grandparent = next(lineage)
             if has_same_colored_children(grandparent):
                 invert_color(grandparent, grandparent.left, grandparent.right)
                 node = grandparent
+                self.publish("recolor", node, node.left, node.right)
                 continue
             # Determine rotation necessary to rebalance tree
             if node is parent.left:

--- a/src/sherwood/trees/redblack.py
+++ b/src/sherwood/trees/redblack.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from itertools import takewhile
+from typing import Any, Iterator, Optional, cast, final
+
+from .base import BinaryNode, Tree
+
+
+class Color(Enum):
+    red = auto()
+    black = auto()
+    __inverted__ = {red: black, black: red}
+
+    @property
+    def inverse(self) -> Color:
+        return Color(self.__inverted__[self.value])
+
+
+@final
+@dataclass(eq=False)
+class RBNode(BinaryNode):
+    color: Color = Color.red
+    left: Optional[RBNode] = None
+    right: Optional[RBNode] = None
+
+
+class RedBlackTree(Tree):
+    root: Optional[RBNode]
+
+    def delete(self, key: Any) -> None:
+        raise NotImplementedError
+
+    def insert(self, key: Any) -> RBNode:
+        if self.root is None:
+            self.root = RBNode(key)
+            self.publish("insert", self.root)
+            return self.root
+
+        lineage = [node := self.root]
+        while True:
+            if key == node.value:
+                raise ValueError(f"duplicate key {key!r} in Red-Black Tree")
+            elif key < node.value:
+                if node.left is not None:
+                    lineage.append(node := node.left)
+                    continue
+                node.left = new = RBNode(key)
+            else:
+                if node.right is not None:
+                    lineage.append(node := node.right)
+                    continue
+                node.right = new = RBNode(key)
+            self.publish("insert", new)
+            self.rebalance(new, reversed(lineage))
+            return new
+
+    def rebalance(self, node: RBNode, lineage: Iterator[RBNode]) -> None:
+        """Rebalances the red-black tree after insertion of a new node."""
+        # lineage traversal includes the 'parent is black' termination condition
+        for parent in takewhile(lambda node: node.color is not Color.black, lineage):
+            if parent is self.root:
+                parent.color = Color.black
+                break
+            grandparent = next(lineage)
+            if has_all_red_children(grandparent):
+                node = grandparent
+                invert_color(node, cast(RBNode, node.left), cast(RBNode, node.right))
+                continue
+            # Determine rotation necessary to rebalance tree
+            if node is parent.left:
+                same = parent is grandparent.left
+                rotate = self.rotate_right if same else self.rotate_right_left
+            else:
+                same = parent is grandparent.right
+                rotate = self.rotate_left if same else self.rotate_left_right
+            # Attach rebalanced subtree to grandparent, or tree root
+            subtree = rotate(grandparent, parent, node)
+            if (anchor := next(lineage, None)) is None:
+                self.root = subtree
+            elif anchor.left is grandparent:
+                anchor.left = subtree
+            else:
+                anchor.right = subtree
+            self.publish("balanced", subtree, subtree.left, subtree.right)
+            if anchor is None or anchor.color is Color.black:
+                break
+            node = anchor
+
+    def rotate_left(self, root: RBNode, pivot: RBNode, tail: RBNode) -> RBNode:
+        """Hoists the pivot up to to be the new root of the given triple."""
+        self.publish("rotate.left", root, pivot, tail)
+        root.right, pivot.left = pivot.left, root
+        invert_color(root, pivot)
+        return pivot
+
+    def rotate_right(self, root: RBNode, pivot: RBNode, tail: RBNode) -> RBNode:
+        """Hoists the pivot up to to be the new root of the given triple."""
+        self.publish("rotate.right", root, pivot, tail)
+        root.left, pivot.right = pivot.right, root
+        invert_color(root, pivot)
+        return pivot
+
+    def rotate_left_right(self, root: RBNode, outer: RBNode, pivot: RBNode) -> RBNode:
+        """Hoists the pivot up to to be the new root of the given triple."""
+        self.publish("rotate.leftright", root, pivot, outer)
+        outer.right, root.left = pivot.left, pivot.right
+        pivot.left, pivot.right = outer, root
+        invert_color(root, pivot)
+        return pivot
+
+    def rotate_right_left(self, root: RBNode, outer: RBNode, pivot: RBNode) -> RBNode:
+        """Hoists the pivot up to to be the new root of the given triple."""
+        self.publish("rotate.rightleft", root, pivot, outer)
+        root.right, outer.left = pivot.left, pivot.right
+        pivot.left, pivot.right = root, outer
+        invert_color(root, pivot)
+        return pivot
+
+
+def has_all_red_children(node: RBNode) -> bool:
+    return (
+        node.left is not None
+        and node.right is not None
+        and node.left.color is node.right.color is Color.red
+    )
+
+
+def invert_color(*nodes: RBNode) -> None:
+    for node in nodes:
+        node.color = node.color.inverse

--- a/src/sherwood/trees/redblack.py
+++ b/src/sherwood/trees/redblack.py
@@ -122,10 +122,36 @@ class RedBlackTree(Tree):
                 self.publish("balanced", subtree, subtree.left, subtree.right)
 
             if not is_black(relation.close_cousin):
-                # D5
+                # D5: Sibling is now black, close cousin is red, double rotate
+                is_left = relation.dir is Branch.left
+                d_rotate = self.rotate_right_left if is_left else self.rotate_left_right
+                subtree = d_rotate(
+                    relation.parent, relation.sibling, relation.close_cousin
+                )
+                subtree.color = relation.parent.color.inverse
+                assert subtree.left is not None
+                assert subtree.right is not None
+                subtree.left.color = Color.black
+                subtree.right.color = Color.black
+                if relation.parent is self.root:
+                    self.root = subtree
+                self.publish("balanced", subtree, subtree.left, subtree.right)
                 return
             elif not is_black(relation.distant_cousin):
-                # D6
+                # D6: Sibling is now black, distant cousin is red, rotate
+                is_left = relation.dir is Branch.left
+                rotate = self.rotate_left if is_left else self.rotate_right
+                subtree = rotate(
+                    relation.parent, relation.sibling, relation.distant_cousin
+                )
+                subtree.color = relation.parent.color.inverse
+                assert subtree.left is not None
+                assert subtree.right is not None
+                subtree.left.color = Color.black
+                subtree.right.color = Color.black
+                if relation.parent is self.root:
+                    self.root = subtree
+                self.publish("balanced", subtree, subtree.left, subtree.right)
                 return
             else:
                 # D4: Sibling is black, both cousins are black, repaint sibling

--- a/src/sherwood/trees/utils.py
+++ b/src/sherwood/trees/utils.py
@@ -1,0 +1,17 @@
+from typing import Iterator, Optional
+
+from ..typing import T_NODE
+
+
+def left_edge_path(node: Optional[T_NODE]) -> Iterator[T_NODE]:
+    """Yields the given node and all children attached on a left edge."""
+    while node is not None:
+        yield node
+        node = node.left
+
+
+def right_edge_path(node: Optional[T_NODE]) -> Iterator[T_NODE]:
+    """Yields the given node and all children attached on a right edge."""
+    while node is not None:
+        yield node
+        node = node.right

--- a/src/sherwood/typing.py
+++ b/src/sherwood/typing.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Optional, Protocol, TypeVar
+
+CT = TypeVar("CT", bound="Comparable")
+
+
+class Comparable(Protocol):
+    def __lt__(self: CT, other: CT) -> bool:
+        ...
+
+
+class Node(Protocol):
+    value: Comparable
+
+    @property
+    def left(self) -> Optional[Node]:
+        ...
+
+    @property
+    def right(self) -> Optional[Node]:
+        ...

--- a/src/sherwood/typing.py
+++ b/src/sherwood/typing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional, Protocol, TypeVar
 
+T = TypeVar("T")
 CT = TypeVar("CT", bound="Comparable")
 T_NODE = TypeVar("T_NODE", bound="Node")
 
@@ -21,3 +22,13 @@ class Node(Protocol):
     @property
     def right(self: T_NODE) -> Optional[T_NODE]:
         ...
+
+
+def unwrap(obj: Optional[T]) -> T:
+    """Type checking helper, asserting that the Optional[T] is actually T.
+
+    Raises AssertionError for values that unexpectedly turn out to be None.
+    """
+    if obj is None:
+        raise AssertionError("Unexpected None value")
+    return obj

--- a/src/sherwood/typing.py
+++ b/src/sherwood/typing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional, Protocol, TypeVar
 
 CT = TypeVar("CT", bound="Comparable")
+T_NODE = TypeVar("T_NODE", bound="Node")
 
 
 class Comparable(Protocol):
@@ -14,9 +15,9 @@ class Node(Protocol):
     value: Comparable
 
     @property
-    def left(self) -> Optional[Node]:
+    def left(self: T_NODE) -> Optional[T_NODE]:
         ...
 
     @property
-    def right(self) -> Optional[Node]:
+    def right(self: T_NODE) -> Optional[T_NODE]:
         ...

--- a/tests/test_redblack.py
+++ b/tests/test_redblack.py
@@ -5,7 +5,7 @@ from typing import Iterable, Union
 
 import pytest
 
-from sherwood.trees.redblack import Color, RBNode, RedBlackTree
+from sherwood.trees.redblack import Color, RBNode, RedBlackTree, is_black
 
 B, R = Color.black, Color.red
 
@@ -24,8 +24,8 @@ def assert_invariants(node):
 
     assert node.color in Color
     if node.color is Color.red:
-        assert node_is_black(node.left)
-        assert node_is_black(node.right)
+        assert is_black(node.left)
+        assert is_black(node.right)
 
     # All paths have the same number of black-colored nodes in them (black-depth)
     paths = list(paths_to_leaf(node))
@@ -42,13 +42,7 @@ def assert_invariants(node):
 
 def black_depth(path):
     """Returns the count of black nodes in an iterable."""
-    return sum(1 for node in path if node.color is Color.black)
-    return sum(map(node_is_black, path))
-
-
-def node_is_black(node):
-    """Returns whether a node is black, with NIL nodes (None) considered black."""
-    return node is None or node.color is Color.black
+    return sum(map(is_black, path))
 
 
 def paths_to_leaf(node):
@@ -99,6 +93,18 @@ def tree_from_values_and_colors(colored_nodes: Iterable[Union[int, Color]]):
         attach(tree.root, node)
     assert_invariants(tree.root)
     return tree
+
+
+@pytest.mark.parametrize(
+    "node, expected",
+    [
+        pytest.param(RBNode(value=1, color=Color.black), True),
+        pytest.param(RBNode(value=1, color=Color.red), False),
+        pytest.param(None, True),
+    ],
+)
+def test_util_is_black(node, expected):
+    assert is_black(node) is expected
 
 
 def test_tree_insert():

--- a/tests/test_redblack.py
+++ b/tests/test_redblack.py
@@ -332,3 +332,53 @@ def test_all_black_rebalancing_recursive(delete):
     assert_invariants(tree.root)
     assert delete not in tree
     assert len(pre_order(tree)) == tree_length - 1
+
+
+@pytest.mark.parametrize("delete", [6, 10])
+def test_rebalance_subtree_under_root(delete):
+    nodes = [8, R, 4, B, 12, B, 2, R, 6, B, 10, B, 14, R, 1, B, 3, B, 13, B, 15, B]
+    tree = tree_from_values_and_colors(nodes)
+    tree_length = len(pre_order(tree))
+
+    tree.delete(delete)
+    assert_invariants(tree.root)
+    assert delete not in tree
+    assert len(pre_order(tree)) == tree_length - 1
+
+
+@pytest.mark.parametrize("delete", [10, 12, 14])
+@pytest.mark.parametrize(
+    "tail",
+    [
+        pytest.param([2, R, 6, B, 10, B, 14, B, 1, B, 3, B], id="distant cousin"),
+        pytest.param([2, B, 6, R, 10, B, 14, B, 5, B, 7, B], id="close cousin"),
+    ],
+)
+def test_rebalance_left_cousin_subtree_under_root(delete, tail):
+    nodes = [16, B, 8, R, 24, B, 4, B, 12, B, 20, B, 28, B]
+    tree = tree_from_values_and_colors(nodes + tail)
+    tree_length = len(pre_order(tree))
+
+    tree.delete(delete)
+    assert_invariants(tree.root)
+    assert delete not in tree
+    assert len(pre_order(tree)) == tree_length - 1
+
+
+@pytest.mark.parametrize("delete", [18, 20, 22])
+@pytest.mark.parametrize(
+    "tail",
+    [
+        pytest.param([18, B, 22, B, 26, B, 30, R, 29, B, 31, B], id="distant cousin"),
+        pytest.param([18, B, 22, B, 26, R, 30, B, 25, B, 27, B], id="close cousin"),
+    ],
+)
+def test_rebalance_right_cousin_subtree_under_root(delete, tail):
+    nodes = [16, B, 8, B, 24, R, 4, B, 12, B, 20, B, 28, B]
+    tree = tree_from_values_and_colors(nodes + tail)
+    tree_length = len(pre_order(tree))
+
+    tree.delete(delete)
+    assert_invariants(tree.root)
+    assert delete not in tree
+    assert len(pre_order(tree)) == tree_length - 1

--- a/tests/test_redblack.py
+++ b/tests/test_redblack.py
@@ -263,6 +263,24 @@ def test_delete_recoloring(nodes, delete):
 @pytest.mark.parametrize(
     "nodes, delete",
     [
+        pytest.param([4, B, 2, B, 6, B, 1, R], 2, id="tail @ left-left"),
+        pytest.param([4, B, 2, B, 6, B, 3, R], 2, id="tail @ left-right"),
+        pytest.param([4, B, 2, B, 6, B, 5, R], 2, id="tail @ right-left"),
+        pytest.param([4, B, 2, B, 6, B, 7, R], 2, id="tail @ right-right"),
+    ],
+)
+def test_delete_hoist_single_red(nodes, delete):
+    tree = tree_from_values_and_colors(nodes)
+    tree_length = len(pre_order(tree))
+    tree.delete(delete)
+    assert_invariants(tree.root)
+    assert delete not in tree
+    assert len(pre_order(tree)) == tree_length - 1
+
+
+@pytest.mark.parametrize(
+    "nodes, delete",
+    [
         pytest.param([4, B, 2, B, 6, R, 5, B, 7, B], 2, id="delete on left"),
         pytest.param([4, B, 2, R, 6, B, 1, B, 3, B], 6, id="delete on right"),
     ],

--- a/tests/test_redblack.py
+++ b/tests/test_redblack.py
@@ -254,3 +254,74 @@ def test_delete_cousin_repainting(nodes, delete):
     assert_invariants(tree.root)
     assert delete not in tree
     assert len(pre_order(tree)) == len(nodes) - 1
+
+
+@pytest.mark.parametrize("delete", [11, 13])
+@pytest.mark.parametrize(
+    "nodes",
+    [
+        pytest.param(
+            [
+                (8, Color.red),
+                (4, Color.black),
+                (12, Color.black),
+                (2, Color.red),
+                (6, Color.black),
+                (11, Color.black),
+                (13, Color.black),
+                (1, Color.black),
+                (3, Color.black),
+            ],
+            id="left-left-leavy",
+        ),
+        pytest.param(
+            [
+                (8, Color.red),
+                (4, Color.black),
+                (12, Color.black),
+                (2, Color.black),
+                (6, Color.red),
+                (11, Color.black),
+                (13, Color.black),
+                (5, Color.black),
+                (7, Color.black),
+            ],
+            id="left-right-leavy",
+        ),
+        pytest.param(
+            [
+                (16, Color.red),
+                (12, Color.black),
+                (20, Color.black),
+                (11, Color.black),
+                (13, Color.black),
+                (18, Color.black),
+                (22, Color.red),
+                (21, Color.black),
+                (23, Color.black),
+            ],
+            id="right-right-heavy",
+        ),
+        pytest.param(
+            [
+                (16, Color.red),
+                (12, Color.black),
+                (20, Color.black),
+                (11, Color.black),
+                (13, Color.black),
+                (18, Color.red),
+                (22, Color.black),
+                (17, Color.black),
+                (19, Color.black),
+            ],
+            id="right-left-heavy",
+        ),
+    ],
+)
+def test_delete_case_cousin_rebalancing(nodes, delete):
+    """Restores black-depth of tree by rotating at cousins of deleted node."""
+    tree = tree_from_values_and_colors(nodes)
+    tree.delete(delete)
+    assert_invariants(tree.root)
+    assert delete not in tree
+    assert len(pre_order(tree)) == len(nodes) - 1

--- a/tests/test_redblack.py
+++ b/tests/test_redblack.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import random
+from itertools import cycle
 
 import pytest
 
@@ -135,3 +135,40 @@ def test_basic_rotations(insert, expected):
     tree = RedBlackTree(insert)
     assert_invariants(tree.root)
     assert pre_order(tree) == expected
+
+
+@pytest.mark.parametrize(
+    "initial, root_color, additional, new_root_color",
+    [
+        pytest.param([5, 6, 3, 4, 2], Color.red, 1, Color.black, id="left side"),
+        pytest.param([2, 1, 4, 3, 5], Color.red, 6, Color.black, id="right side"),
+    ],
+)
+def test_double_recolor(initial, root_color, additional, new_root_color):
+    tree = RedBlackTree(initial)
+    assert tree.root.color is root_color
+    tree.insert(additional)
+    assert tree.root.color is new_root_color
+
+
+def test_triple_recolor():
+    """Recoloring continues towards the root or until rotations are required."""
+
+    def left_edge(node):
+        yield node.value, node.color
+        if node.left is not None:
+            yield from left_edge(node.left)
+
+    tree = RedBlackTree([13, 16, 8, 17, 15, 11, 5, 14, 12, 10, 6, 3, 9, 4, 2])
+    red_root_values = zip([13, 8, 5, 3, 2], cycle([Color.red, Color.black]))
+    assert list(left_edge(tree.root)) == list(red_root_values)
+    tree.insert(1)
+    black_root_values = zip([13, 8, 5, 3, 2, 1], cycle([Color.black, Color.red]))
+    assert list(left_edge(tree.root)) == list(black_root_values)
+
+
+def test_example():
+    tree = RedBlackTree()
+    for value in [43, 81, 95, 16, 28, 23, 63, 57]:
+        tree.insert(value)
+        assert_invariants(tree.root)

--- a/tests/test_redblack.py
+++ b/tests/test_redblack.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from sherwood.trees.redblack import Color, RedBlackTree
+
+
+def assert_invariants(node):
+    """Asserts the Red-Black tree invariants for the given node and all child nodes
+
+    - Asserts that the node's color is either `Color.red` or `Color.black`;
+    - Asserts children of a red colored node are both colored black;
+    - Asserts that all paths from the node down to any of the leaves passes
+      through an equal number of black-colored nodes;
+    - Asserts that the left child (if any) is smaller, and the inverse for the right
+    """
+    if node is None:
+        return
+
+    assert node.color in Color
+    if node.color is Color.red:
+        assert node_is_black(node.left)
+        assert node_is_black(node.right)
+
+    # All paths have the same number of black-colored nodes in them (black-depth)
+    paths = list(paths_to_leaf(node))
+    assert len(set(map(black_depth, paths))) == 1
+
+    # Base binary tree validation and recursive checks down
+    if node.left is not None:
+        assert node.left.value < node.value
+        assert_invariants(node.left)
+    if node.right is not None:
+        assert node.value < node.right.value
+        assert_invariants(node.right)
+
+
+def black_depth(path):
+    """Returns the count of black nodes in an iterable."""
+    return sum(1 for node in path if node.color is Color.black)
+    return sum(map(node_is_black, path))
+
+
+def node_is_black(node):
+    """Returns whether a node is black, with NIL nodes (None) considered black."""
+    return node is None or node.color is Color.black
+
+
+def paths_to_leaf(node):
+    def _dfs(node, stack):
+        if node is None:
+            yield stack
+        else:
+            yield from _dfs(node.left, stack + (node,))
+            yield from _dfs(node.right, stack + (node,))
+
+    yield from _dfs(node, ())
+
+
+def pre_order(tree):
+    """Returns a pre-order tree traversal as a list."""
+
+    def _traversal(node):
+        if node is not None:
+            yield node.value
+            yield from _traversal(node.left)
+            yield from _traversal(node.right)
+
+    return list(_traversal(tree.root))
+
+
+def test_tree_insert():
+    tree = RedBlackTree()
+    tree.insert(5)
+    assert 5 in tree
+
+
+def test_instantiate_from_list():
+    tree = RedBlackTree([1, 2])
+    assert 1 in tree
+    assert 2 in tree
+
+
+def test_instantiate_from_iter():
+    tree = RedBlackTree(range(1, 3))
+    assert 1 in tree
+    assert 2 in tree
+
+
+def test_instantiate_from_string():
+    tree = RedBlackTree("abc")
+    assert "a" in tree
+    assert "b" in tree
+    assert "c" in tree
+
+
+def test_double_insert_exception():
+    tree = RedBlackTree([5])
+    with pytest.raises(ValueError):
+        tree.insert(5)
+
+
+@pytest.mark.parametrize(
+    "insert, expected_root_color, expected_pre_order",
+    [
+        pytest.param([4, 2], Color.black, [4, 2], id="left heavy"),
+        pytest.param([4, 6], Color.black, [4, 6], id="right heavy"),
+        pytest.param([4, 2, 6, 1], Color.red, [4, 2, 1, 6], id="row color swap"),
+        pytest.param([4, 2, 6, 3], Color.red, [4, 2, 3, 6], id="row color swap"),
+        pytest.param([4, 2, 6, 5], Color.red, [4, 2, 6, 5], id="row color swap"),
+        pytest.param([4, 2, 6, 7], Color.red, [4, 2, 6, 7], id="row color swap"),
+    ],
+)
+def test_rotationless_recoloring(insert, expected_root_color, expected_pre_order):
+    """Tests recoloring of tree nodes without requiring rotations."""
+    tree = RedBlackTree(insert)
+    assert_invariants(tree.root)
+    assert tree.root.color is expected_root_color
+    assert pre_order(tree) == expected_pre_order
+
+
+@pytest.mark.parametrize(
+    "insert, expected",
+    [
+        pytest.param([1, 2, 3], [2, 1, 3], id="left rotation"),
+        pytest.param([3, 2, 1], [2, 1, 3], id="right rotation"),
+        pytest.param([1, 3, 2], [2, 1, 3], id="right-left rotation"),
+        pytest.param([3, 1, 2], [2, 1, 3], id="left-right rotation"),
+    ],
+)
+def test_basic_rotations(insert, expected):
+    """Tests basic tree rotations."""
+    tree = RedBlackTree(insert)
+    assert_invariants(tree.root)
+    assert pre_order(tree) == expected


### PR DESCRIPTION
Adds an implementation of a Red-Black tree without parent references.

* Refactors the rendering to allow property-based rendering;
* Default colored markers for operations changes to outlines rather than node colors;
* Added node coloring for red/black distinction;
* Separated a number of shared utility functions out to their own module;
* Cleans up some typing, removing `cast` in favor of "proof of not-None".